### PR TITLE
fix: names() -> keys()

### DIFF
--- a/src/qcg/appscheduler/api/manager.py
+++ b/src/qcg/appscheduler/api/manager.py
@@ -455,7 +455,7 @@ class Manager:
         This method waits until all specified jobs finish its execution (successfully or not).
         See 'wait4'.
         """
-        self.wait4(self.list().names())
+        self.wait4(self.list().keys())
 
 
     def isStatusFinished(self, status):


### PR DESCRIPTION
In the wait4all method there is a need to get all names of tasks, however the list returned by list() doesn't offer the names() method. Since the list() returns a dictionary, the keys() seem to be a correct method for this task.