### PR TITLE
the mp start method is set to fork only when not initialized before

### DIFF
--- a/src/qcg/pilotjob/api/manager.py
+++ b/src/qcg/pilotjob/api/manager.py
@@ -656,8 +656,11 @@ class LocalManager(Manager):
               'log_file' - the location of the log file
               'log_level' - the log level ('DEBUG'); by default the log level is set to INFO
         """
-#        if not mp.get_context():
-        mp.set_start_method('spawn', force=True)
+        if not mp.get_context():
+            logging.debug('initializing MP start method with "fork"')
+            mp.set_start_method('fork')
+        else:
+            logging.debug(f'MP start method already initialized with {mp.get_context().get_start_method()} method')
 
         try:
             from qcg.pilotjob.service import QCGPMServiceProcess


### PR DESCRIPTION
The start method for multiprocessing python's package is set to 'fork' only when not initialized before. For some environments, like Jupyter the 'spawn' method might be more usable, but such settings should be done in block protected with 'if __name__ == "__main__"' as documentation suggest (with 'spawn' method the initialization block will be called also for spawned process but with different '__name__'). So different settings must be done in scripts that uses QCG-PJ LocalManager class.