### PR TITLE
Logging improvements

### DIFF
--- a/src/qcg/pilotjob/__init__.py
+++ b/src/qcg/pilotjob/__init__.py
@@ -1,2 +1,6 @@
+import logging
+
 __version__="issue_62_api_docs"
 
+
+logger = logging.getLogger(__name__)

--- a/src/qcg/pilotjob/api/manager.py
+++ b/src/qcg/pilotjob/api/manager.py
@@ -9,6 +9,7 @@ from os.path import exists, join, dirname, abspath
 import multiprocessing as mp
 
 import zmq
+from qcg.pilotjob import logger as top_logger
 from qcg.pilotjob.api import errors
 from qcg.pilotjob.api.jobinfo import JobInfo
 
@@ -52,7 +53,6 @@ class Manager:
         self._poll_delay = Manager.DEFAULT_POLL_DELAY
 
         self._log_handler = None
-        self._root_logger = None
 
         client_cfg = cfg or {}
         self._setup_logging(client_cfg)
@@ -108,17 +108,16 @@ class Manager:
         elif exists(_log_file):
             os.remove(_log_file)
 
-        self._root_logger = logging.getLogger()
         self._log_handler = logging.FileHandler(filename=_log_file, mode='a', delay=False)
         self._log_handler.setFormatter(logging.Formatter('%(asctime)-15s: %(message)s'))
-        self._root_logger.addHandler(self._log_handler)
+        top_logger.addHandler(self._log_handler)
 
         level = logging.INFO
         if 'log_level' in cfg:
             if cfg['log_level'].lower() == 'debug':
                 level = logging.DEBUG
 
-        self._root_logger.setLevel(level)
+        top_logger.setLevel(level)
 
     def _disconnect(self):
         """Close connection to the QCG-PJM
@@ -511,11 +510,11 @@ class Manager:
     def cleanup(self):
         """Clean up resources.
 
-        The custom logging handlers are removed from root logger.
+        The custom logging handlers are removed from top logger.
         """
         if self._log_handler:
             self._log_handler.close()
-            self._root_logger.removeHandler(self._log_handler)
+            top_logger.removeHandler(self._log_handler)
 
     def wait4(self, names):
         """Wait for finish of specific jobs.

--- a/src/qcg/pilotjob/api/manager.py
+++ b/src/qcg/pilotjob/api/manager.py
@@ -101,7 +101,6 @@ class Manager:
         """
         wdir = cfg.get('wdir', '.')
         _log_file = cfg.get('log_file', join(wdir, '.qcgpjm-client', 'api.log'))
-        print('log file set to {}'.format(_log_file))
 
         if not exists(dirname(abspath(_log_file))):
             os.makedirs(dirname(abspath(_log_file)))

--- a/src/qcg/pilotjob/client_cmd.py
+++ b/src/qcg/pilotjob/client_cmd.py
@@ -15,6 +15,9 @@ DEFAULT_PORT = '21000'
 AUX_DIR_PTRN = re.compile(r'\.qcgpjm-service-.*')
 
 
+_logger = logging.getLogger(__name__)
+
+
 class TimeoutError(Exception):
     pass
 
@@ -58,7 +61,7 @@ def get_address_from_arg(address):
 
 
 def zmq_connect(pjm_ctx):
-    logging.debug('qcg pjm network interface address: {}'.format(str(pjm_ctx['address'])))
+    _logger.debug('qcg pjm network interface address: {}'.format(str(pjm_ctx['address'])))
 
     zmq_ctx = {}
     zmq_ctx['ctx'] = zmq.Context.instance()
@@ -66,7 +69,7 @@ def zmq_connect(pjm_ctx):
     zmq_ctx['sock'].setsockopt(zmq.LINGER, 0)
     zmq_ctx['sock'].connect(pjm_ctx['address'])
 
-    logging.debug('zmq connection created for service @ {}'.format(str(pjm_ctx['address'])))
+    _logger.debug('zmq connection created for service @ {}'.format(str(pjm_ctx['address'])))
     return zmq_ctx
 
 
@@ -75,7 +78,7 @@ def zmq_request(zmq_ctx, request, timeout_secs):
         "request": request
     })))
 
-    logging.debug('\'{}\' request send - waiting for reponse'.format(request))
+    _logger.debug('\'{}\' request send - waiting for reponse'.format(request))
 
     poller = zmq.Poller()
     poller.register(zmq_ctx['sock'], zmq.POLLIN)
@@ -117,13 +120,13 @@ def qcgpjm(ctx, path, address, debug):
             raise Exception('unable to find QCG PJM network interface address (use \'-p\' or \'-a\' argument)')
 
         pjm_ctx = { 'path': pjm_path, 'address': pjm_address }
-        logging.debug('qcg pjm network interface address: {}'.format(str(pjm_ctx['address'])))
+        _logger.debug('qcg pjm network interface address: {}'.format(str(pjm_ctx['address'])))
 
         ctx.ensure_object(dict)
         ctx.obj['pjm'] = pjm_ctx
     except Exception as e:
         click.echo('error: {}'.format(str(e)), err=True)
-        logging.error(traceback.format_exc())
+        _logger.error(traceback.format_exc())
         sys.exit(1)
 
 
@@ -141,11 +144,11 @@ def status(ctx):
         except TimeoutError:
             # try to read final status - if exists
             if pjm_ctx.get('path') and exists(join(pjm_ctx['path'], 'final_status')):
-                logging.debug('reading final status from file {}'.format(join(pjm_ctx['path'], 'final_status')))
+                _logger.debug('reading final status from file {}'.format(join(pjm_ctx['path'], 'final_status')))
                 with open(join(pjm_ctx['path'], 'final_status')) as f:
                     response = json.loads(f.read())
             else:
-                logging.info('failed to find the final status file in path {}'.format(pjm_ctx.get('path')))
+                _logger.info('failed to find the final status file in path {}'.format(pjm_ctx.get('path')))
                 raise
 
         status = validate_response(response)
@@ -156,7 +159,7 @@ def status(ctx):
                 print('{}={}'.format(key, value))
     except Exception as e:
         click.echo('error: {}'.format(str(e)), err=True)
-        logging.error(traceback.format_exc())
+        _logger.error(traceback.format_exc())
 
 
 

--- a/src/qcg/pilotjob/environment.py
+++ b/src/qcg/pilotjob/environment.py
@@ -6,6 +6,9 @@ from qcg.pilotjob.slurmres import in_slurm_allocation
 from qcg.pilotjob.resources import CRType
 
 
+_logger = logging.getLogger(__name__)
+
+
 class Environment:
     """Base class for setting job's environment variables.
 
@@ -37,10 +40,10 @@ class CommonEnvironment(Environment):
 
     def __init__(self):
         super(CommonEnvironment, self).__init__()
-        logging.info('initializing COMMON environment')
+        _logger.info('initializing COMMON environment')
 
     def update_env(self, job, env, opts=None):
-        logging.debug('updating common environment')
+        _logger.debug('updating common environment')
 
         env.update({
             'QCG_PM_NNODES': str(job.nnodes),
@@ -59,7 +62,7 @@ class SlurmEnvironment(Environment):
 
     def __init__(self):
         super(SlurmEnvironment, self).__init__()
-        logging.info('initializing SLURM environment')
+        _logger.info('initializing SLURM environment')
 
     @staticmethod
     def _merge_per_node_spec(str_list):
@@ -136,9 +139,9 @@ class SlurmEnvironment(Environment):
             job.env.update({
                 'SLURM_HOSTFILE': hostfile
             })
-            logging.debug('host file generated at %s', hostfile)
+            _logger.debug('host file generated at %s', hostfile)
         else:
-            logging.debug('not generating hostfile')
+            _logger.debug('not generating hostfile')
 
         node_with_gpu_crs = [node for node in job.allocation.nodes
                              if node.crs is not None and CRType.GPU in node.crs]

--- a/src/qcg/pilotjob/executionjob.py
+++ b/src/qcg/pilotjob/executionjob.py
@@ -12,6 +12,9 @@ from qcg.pilotjob.launcher.launcher import Launcher
 import qcg.pilotjob.profile
 
 
+_logger = logging.getLogger(__name__)
+
+
 class ExecutionJob:
     """
     Class is responsible for executing a single job iteration inside allocation.
@@ -210,7 +213,7 @@ class ExecutionJob:
 
             await self.launch()
         except Exception as ex:
-            logging.exception("failed to start job %s", self.job_iteration.name)
+            _logger.exception("failed to start job %s", self.job_iteration.name)
             self.postprocess(-1, str(ex))
 
 
@@ -271,7 +274,7 @@ class LocalSchemaExecutionJob(ExecutionJob):
                                                                                                 jexec.stderr)
                     stderr_p = open(stderr_path, 'w')
 
-            logging.debug("launching job %s: %s %s", self.job_iteration.name, jexec.exec, str(jexec.args))
+            _logger.debug("launching job %s: %s %s", self.job_iteration.name, jexec.exec, str(jexec.args))
 
             process = await asyncio.create_subprocess_exec(
                 jexec.exec, *jexec.args,
@@ -283,17 +286,17 @@ class LocalSchemaExecutionJob(ExecutionJob):
                 shell=False,
             )
 
-            logging.info("local process %d for job %s launched", process.pid, self.job_iteration.name)
+            _logger.info("local process %d for job %s launched", process.pid, self.job_iteration.name)
 
             await process.wait()
 
-            logging.info("local process for job %s finished", self.job_iteration.name)
+            _logger.info("local process for job %s finished", self.job_iteration.name)
 
             exit_code = process.returncode
 
             self.postprocess(exit_code)
         except Exception as exc:
-            logging.exception("execution failed: %s", str(exc))
+            _logger.exception("execution failed: %s", str(exc))
             self.postprocess(-1, str(exc))
         finally:
             try:
@@ -304,7 +307,7 @@ class LocalSchemaExecutionJob(ExecutionJob):
                 if stderr_p not in [asyncio.subprocess.DEVNULL, stdout_p]:
                     stderr_p.close()
             except Exception as exc:
-                logging.error("cleanup failed: %s", str(exc))
+                _logger.error("cleanup failed: %s", str(exc))
 
     @profile
     async def launch(self):

--- a/src/qcg/pilotjob/executionschema.py
+++ b/src/qcg/pilotjob/executionschema.py
@@ -5,6 +5,9 @@ from qcg.pilotjob.errors import InternalError
 from qcg.pilotjob.resources import ResourcesType
 
 
+_logger = logging.getLogger(__name__)
+
+
 class ExecutionSchema:
     """Method of executing job.
     Currently two methods are supported:
@@ -303,7 +306,7 @@ class SlurmExecution(ExecutionSchema):
         """
         job_model = ex_job.job_execution.model or 'default'
 
-        logging.info(f'looking for job model {job_model}')
+        _logger.info(f'looking for job model {job_model}')
         preprocess_method = SlurmExecution.JOB_MODELS.get(job_model)
         if not preprocess_method:
             raise InternalError(f"unknown job execution model '{job_model}'")

--- a/src/qcg/pilotjob/executionschema.py
+++ b/src/qcg/pilotjob/executionschema.py
@@ -1,6 +1,7 @@
 import os
 import logging
 
+from qcg.pilotjob import logger as top_logger
 from qcg.pilotjob.errors import InternalError
 from qcg.pilotjob.resources import ResourcesType
 
@@ -246,7 +247,7 @@ class SlurmExecution(ExecutionSchema):
         else:
             mpi_args = ['-n', f'{str(ex_job.ncores)}', f'{job_exec}']
 
-        if logging.root.level == logging.DEBUG:
+        if top_logger.level == logging.DEBUG:
             ex_job.env.update({'I_MPI_HYDRA_BOOTSTRAP_EXEC_EXTRA_ARGS':
                                    '-vvvvvv --overcommit --oversubscribe --cpu-bind=none --mem-per-cpu=0'})
             ex_job.env.update({'I_MPI_HYDRA_DEBUG': '1'})

--- a/src/qcg/pilotjob/fileinterface.py
+++ b/src/qcg/pilotjob/fileinterface.py
@@ -7,6 +7,9 @@ from qcg.pilotjob.errors import JobFileNotExist, IllegalJobDescription
 from qcg.pilotjob.config import Config
 
 
+_logger = logging.getLogger(__name__)
+
+
 class FileInterface:
     """Interface for reading requests from file.
 
@@ -51,7 +54,7 @@ class FileInterface:
             with open(self.path) as json_file:
                 self.data = json.load(json_file)
         except Exception as exc:
-            logging.error("Fail to parse job description: %s", str(exc.args[0]))
+            _logger.error("Fail to parse job description: %s", str(exc.args[0]))
             raise IllegalJobDescription("Wrong job description: {}".format(str(exc.args[0])))
 
         if not isinstance(self.data, list):
@@ -87,4 +90,4 @@ class FileInterface:
 
         Because file interface is used in batch mode, the response is ignored.
         """
-        logging.info("FileInterface reply message: %s", reply_msg)
+        _logger.info("FileInterface reply message: %s", reply_msg)

--- a/src/qcg/pilotjob/iterscheduler.py
+++ b/src/qcg/pilotjob/iterscheduler.py
@@ -11,6 +11,9 @@ import math
 from qcg.pilotjob.errors import InvalidRequest
 
 
+_logger = logging.getLogger(__name__)
+
+
 class IterScheduler:
     """Iteration resources schedulers utility class."""
 
@@ -87,7 +90,7 @@ class MaximumIters:
         Raises:
             InvalidRequest: when parameter ``max`` is used in resource description
         """
-        logging.debug("iteration scheduler '%s' algorithm called", MaximumIters.SCHED_NAME)
+        _logger.debug("iteration scheduler '%s' algorithm called", MaximumIters.SCHED_NAME)
 
         if 'max' in self.job_resources:
             raise InvalidRequest(
@@ -99,7 +102,7 @@ class MaximumIters:
 
         if self.iterations * pmin <= self.avail_resources:
             # a single round
-            logging.debug("iterations in single round to schedule: %s, available resources: %s, "
+            _logger.debug("iterations in single round to schedule: %s, available resources: %s, "
                           "minimum iteration resources: %s", self.iterations, self.avail_resources, pmin)
 
             avail_resources = self.avail_resources
@@ -108,7 +111,7 @@ class MaximumIters:
                 iteration_resources = math.floor(avail_resources / (self.iterations - iteration))
                 avail_resources -= iteration_resources
 
-                logging.debug("iteration: %s/%s, iteration_resources: %s, rest avail_resources: %s",
+                _logger.debug("iteration: %s/%s, iteration_resources: %s, rest avail_resources: %s",
                               iteration, self.iterations, iteration_resources, avail_resources)
 
                 yield IterScheduler.get_exact_iter_plan(self.job_resources.copy(), iteration_resources)
@@ -119,7 +122,7 @@ class MaximumIters:
             rounds = math.ceil((self.iterations / math.floor(float(self.avail_resources) / pmin)))
             iterations_to_schedule = self.iterations
 
-            logging.debug("iterations to schedule: %s, rounds: %s, resources: %s, minimum iteration "
+            _logger.debug("iterations to schedule: %s, rounds: %s, resources: %s, minimum iteration "
                           "resources: %s", iterations_to_schedule, rounds, self.avail_resources, pmin)
 
             while iterations_to_schedule > 0:
@@ -127,21 +130,21 @@ class MaximumIters:
                     iterations_in_round = math.ceil(iterations_to_schedule / (rounds - ex_round))
                     round_resources = self.avail_resources
 
-                    logging.debug("round: %s/%s, iterations_in_round: %s", ex_round, rounds, iterations_in_round)
+                    _logger.debug("round: %s/%s, iterations_in_round: %s", ex_round, rounds, iterations_in_round)
 
                     for iteration_in_round in range(iterations_in_round):
                         # assign part of round_resources to the iteration_in_round
                         iteration_resources = math.floor(round_resources / (iterations_in_round - iteration_in_round))
                         round_resources -= iteration_resources
 
-                        logging.debug("round: %s/%s, iteration_in_round: %s/%s, iteration_resources: %s, rest "
+                        _logger.debug("round: %s/%s, iteration_in_round: %s/%s, iteration_resources: %s, rest "
                                       "round_resources: %s", ex_round, rounds, iteration_in_round, iterations_in_round,
                                       iteration_resources, round_resources)
 
                         yield IterScheduler.get_exact_iter_plan(self.job_resources.copy(), iteration_resources)
 
                     iterations_to_schedule -= iterations_in_round
-                    logging.debug("end of round: %s/%s, iterations_to_schedule: %s", ex_round, rounds,
+                    _logger.debug("end of round: %s/%s, iterations_to_schedule: %s", ex_round, rounds,
                                   iterations_to_schedule)
 
 
@@ -183,7 +186,7 @@ class SplitInto:
         Raises:
             InvalidRequest: when parameter ``max`` is used in resource description
         """
-        logging.debug("iteration scheduler '%s' algorithm called", SplitInto.SCHED_NAME)
+        _logger.debug("iteration scheduler '%s' algorithm called", SplitInto.SCHED_NAME)
 
         if 'max' in self.job_resources:
             raise InvalidRequest(
@@ -193,7 +196,7 @@ class SplitInto:
         if split_part <= 0:
             raise InvalidRequest('Wrong submit request - split-into resolved to zero')
 
-        logging.debug("split-into algorithm of %s self.iterations with %s split-into on %s self.avail_resources "
+        _logger.debug("split-into algorithm of %s self.iterations with %s split-into on %s self.avail_resources "
                       "finished with %s splits", self.iterations, self.split_into, self.avail_resources, split_part)
 
         for _ in range(0, self.iterations):

--- a/src/qcg/pilotjob/joblist.py
+++ b/src/qcg/pilotjob/joblist.py
@@ -9,6 +9,9 @@ from qcg.pilotjob.resources import CRType
 from qcg.pilotjob.errors import JobAlreadyExist, IllegalResourceRequirements, IllegalJobDescription
 
 
+_logger = logging.getLogger(__name__)
+
+
 class JobState(Enum):
     """The job state."""
 
@@ -937,7 +940,7 @@ class Job:
         """
         assert isinstance(state, JobState), "Wrong state type"
 
-        logging.debug('job %s iteration %s status changed to %s (final ? %s)', self._name, iteration, state.name,
+        _logger.debug('job %s iteration %s status changed to %s (final ? %s)', self._name, iteration, state.name,
                       state.is_finished())
 
         if iteration is not None:
@@ -949,7 +952,7 @@ class Job:
                 if state in [JobState.FAILED, JobState.OMITTED, JobState.CANCELED]:
                     self._subjobs_failed += 1
 
-                logging.debug('currently not finished subjobs %s, failed %s', self._subjobs_not_finished,
+                _logger.debug('currently not finished subjobs %s, failed %s', self._subjobs_not_finished,
                               self._subjobs_failed)
 
                 if self._subjobs_not_finished == 0 and not self._state.is_finished():

--- a/src/qcg/pilotjob/launcher/launcher.py
+++ b/src/qcg/pilotjob/launcher/launcher.py
@@ -10,6 +10,8 @@ from datetime import datetime
 import zmq
 from zmq.asyncio import Context
 
+from qcg.pilotjob import logger as top_logger
+
 
 _logger = logging.getLogger(__name__)
 
@@ -353,7 +355,7 @@ class Launcher:
                       '--mem-per-cpu=0', '--oversubscribe', '--overcommit', '-N', '1', '-n', '1', '-D', self.work_dir,
                       '-u']
 
-        if logging.root.level == logging.DEBUG:
+        if top_logger.level == logging.DEBUG:
             slurm_args.extend(['--slurmd-debug=verbose', '-vvvvv'])
 
         slurm_args.extend(slurm_data.get('args', []))
@@ -361,7 +363,7 @@ class Launcher:
         stdout_p = asyncio.subprocess.DEVNULL
         stderr_p = asyncio.subprocess.DEVNULL
 
-        if logging.root.level == logging.DEBUG:
+        if top_logger.level == logging.DEBUG:
             stdout_p = open(os.path.join(self.aux_dir, 'nl-{}-start-agent-stdout.log'.format(slurm_data['node'])), 'w')
             stderr_p = open(os.path.join(self.aux_dir, 'nl-{}-start-agent-stderr.log'.format(slurm_data['node'])), 'w')
 

--- a/src/qcg/pilotjob/launcher/launcher.py
+++ b/src/qcg/pilotjob/launcher/launcher.py
@@ -11,6 +11,9 @@ import zmq
 from zmq.asyncio import Context
 
 
+_logger = logging.getLogger(__name__)
+
+
 class Launcher:
     """The launcher service used to launch applications on remote nodes.
 
@@ -102,11 +105,11 @@ class Launcher:
         """
         try:
             await self._init_input_iface(local_port=local_port)
-            logging.debug('local manager listening at %s', self.local_address)
+            _logger.debug('local manager listening at %s', self.local_address)
 
             await self.__fire_agents(instances)
         except Exception as exc:
-            logging.error('failed to start agents: %s', str(exc))
+            _logger.error('failed to start agents: %s', str(exc))
             await self._cleanup()
             raise
 
@@ -132,7 +135,7 @@ class Launcher:
             finish_cb_args - job finish callback arguments
         """
         if agent_id not in self.agents:
-            logging.error('agent %s not registered', agent_id)
+            _logger.error('agent %s not registered', agent_id)
             raise Exception('agent {} not registered'.format(agent_id))
 
         if finish_cb:
@@ -157,14 +160,14 @@ class Launcher:
             msg = await out_socket.recv_json()
 
             if not msg.get('status', None) == 'OK':
-                logging.error('failed to run application %s by agent %s: %s', app_id, agent_id, str(msg))
+                _logger.error('failed to run application %s by agent %s: %s', app_id, agent_id, str(msg))
 
                 if finish_cb:
                     del self.jobs_cb[app_id]
 
                 raise Exception('failed to run application {} by agent {}: {}'.format(app_id, agent_id, str(msg)))
 
-            logging.debug('application %s successfully launched by agent %s', app_id, agent_id)
+            _logger.debug('application %s successfully launched by agent %s', app_id, agent_id)
         finally:
             if out_socket:
                 try:
@@ -185,7 +188,7 @@ class Launcher:
 
         # kill agent processes
         await self._cancel_agents()
-        logging.debug('launcher agents canceled')
+        _logger.debug('launcher agents canceled')
 
         # cancel input interface task
         if self.iface_task:
@@ -193,15 +196,15 @@ class Launcher:
 
             try:
                 await self.iface_task
-                logging.debug('launcher iface receiver closed')
+                _logger.debug('launcher iface receiver closed')
             except asyncio.CancelledError:
-                logging.debug('input interface task finished')
+                _logger.debug('input interface task finished')
 
         # close input interface socket
         if self.in_socket:
             self.in_socket.close()
 
-        logging.debug('launcher iface socket closed')
+        _logger.debug('launcher iface socket closed')
 
     async def _shutdown_agents(self):
         """Signal all running node agents to shutdown and wait for notification about finishing."""
@@ -212,7 +215,7 @@ class Launcher:
             nodes = self.nodes.copy()
 
             for agent_id, agent in nodes.items():
-                logging.debug('connecting to node agent %s @ %s ...', agent_id, agent['address'])
+                _logger.debug('connecting to node agent %s @ %s ...', agent_id, agent['address'])
 
                 try:
                     out_socket.connect(agent['address'])
@@ -222,19 +225,19 @@ class Launcher:
                     msg = await out_socket.recv_json()
 
                     if not msg.get('status', None) == 'OK':
-                        logging.error('failed to finish node agent %s: %s', agent_id, str(msg))
+                        _logger.error('failed to finish node agent %s: %s', agent_id, str(msg))
                     else:
-                        logging.debug('node agent %s signaled to shutdown', agent_id)
+                        _logger.debug('node agent %s signaled to shutdown', agent_id)
 
                     out_socket.disconnect(agent['address'])
                 except Exception as exc:
-                    logging.error('failed to signal agent to shutdown: %s', str(exc))
+                    _logger.error('failed to signal agent to shutdown: %s', str(exc))
 
             start_t = datetime.now()
 
             while len(self.nodes) > 0:
                 if (datetime.now() - start_t).total_seconds() > Launcher.SHUTDOWN_TIMEOUT_SECS:
-                    logging.error('timeout while waiting for agents exit - currenlty not finished %d: %s',
+                    _logger.error('timeout while waiting for agents exit - currenlty not finished %d: %s',
                                   len(self.nodes), str(','.join(self.nodes.keys())))
                     raise Exception('timeout while waiting for agents exit')
 
@@ -251,12 +254,12 @@ class Launcher:
         """Kill agent processes. """
         for agent_id, agent in self.agents.items():
             if agent.get('process', None):
-                logging.debug('killing agent %s ...', agent_id)
+                _logger.debug('killing agent %s ...', agent_id)
                 try:
                     await asyncio.wait_for(agent['process'].wait(), 5)
                     agent['process'] = None
                 except Exception:
-                    logging.warning('Failed to kill agent: %s', str(sys.exc_info()))
+                    _logger.warning('Failed to kill agent: %s', str(sys.exc_info()))
                 finally:
                     try:
                         if agent['process']:
@@ -287,7 +290,7 @@ class Launcher:
             if not proto:
                 proto = 'local'
 
-            logging.info('running node agent %s via %s', idata['agent_id'], proto)
+            _logger.info('running node agent %s via %s', idata['agent_id'], proto)
 
             agent_args = [idata['agent_id'], self.local_export_address]
             if idata.get('options'):
@@ -308,13 +311,13 @@ class Launcher:
 
         while len(self.nodes) < len(self.agents):
             if (datetime.now() - start_t).total_seconds() > Launcher.START_TIMEOUT_SECS:
-                logging.error('timeout while waiting for agents - currenlty registered %s from launched %s',
+                _logger.error('timeout while waiting for agents - currenlty registered %s from launched %s',
                               len(self.nodes), len(self.agents))
                 raise Exception('timeout while waiting for agents')
 
             await asyncio.sleep(0.2)
 
-        logging.debug('all agents %d registered in %d seconds', len(self.nodes),
+        _logger.debug('all agents %d registered in %d seconds', len(self.nodes),
                       (datetime.now() - start_t).total_seconds())
 
     async def __fire_ssh_agent(self, ssh_data, args):
@@ -362,7 +365,7 @@ class Launcher:
             stdout_p = open(os.path.join(self.aux_dir, 'nl-{}-start-agent-stdout.log'.format(slurm_data['node'])), 'w')
             stderr_p = open(os.path.join(self.aux_dir, 'nl-{}-start-agent-stderr.log'.format(slurm_data['node'])), 'w')
 
-        logging.debug('running agent process with args: %s', ' '.join(
+        _logger.debug('running agent process with args: %s', ' '.join(
             [shutil.which('srun')] + slurm_args + self.node_local_agent_cmd + args))
 
         return await asyncio.create_subprocess_exec(shutil.which('srun'), *slurm_args,
@@ -403,7 +406,7 @@ class Launcher:
         self.local_address = address
         self.local_export_address = '{}://{}:{}'.format(proto, socket.gethostbyname(socket.gethostname()), port)
 
-        logging.debug('local address accessible by other machines: %s', self.local_export_address)
+        _logger.debug('local address accessible by other machines: %s', self.local_export_address)
 
         self.iface_task = asyncio.ensure_future(self._input_iface())
 
@@ -414,21 +417,21 @@ class Launcher:
         while True:
             msg = await self.in_socket.recv_json()
 
-            logging.debug('received message: %s', str(msg))
+            _logger.debug('received message: %s', str(msg))
 
             if msg.get('status', None) == 'READY':
                 try:
                     if not all(('agent_id' in msg, 'local_address' in msg)):
                         raise Exception('missing identifier/local address in ready message')
                 except Exception as exc:
-                    logging.error('error: %s', str(exc))
+                    _logger.error('error: %s', str(exc))
                     await self.in_socket.send_json({'status': 'ERROR', 'message': str(exc)})
                     next
                 else:
                     await self.in_socket.send_json({'status': 'CONFIRMED'})
 
                 self.nodes[msg['agent_id']] = {'registered_at': datetime.now(), 'address': msg['local_address']}
-                logging.debug('registered at (%s) agent (%s) listening at (%s)',
+                _logger.debug('registered at (%s) agent (%s) listening at (%s)',
                               self.nodes[msg['agent_id']]['registered_at'],
                               msg['agent_id'], self.nodes[msg['agent_id']]['address'])
             elif msg.get('status', None) in ['APP_FINISHED', 'APP_FAILED']:
@@ -436,37 +439,37 @@ class Launcher:
 
                 appid = msg.get('appid', 'UNKNOWN')
 
-                logging.debug('received notification with application %s finish %s', appid, str(msg))
+                _logger.debug('received notification with application %s finish %s', appid, str(msg))
 
                 if appid in self.jobs_cb:
                     try:
                         args = (*self.jobs_cb[appid]['args'], msg) if self.jobs_cb[appid]['args'] else (msg)
-                        logging.debug('calling application finish callback with object %s and args %s',
+                        _logger.debug('calling application finish callback with object %s and args %s',
                                       self.jobs_cb[appid]['f'], str(args))
                         self.jobs_cb[appid]['f'](args)
                     except Exception as exc:
-                        logging.error('failed to call application finish callback: %s', str(exc))
+                        _logger.error('failed to call application finish callback: %s', str(exc))
 
                     del self.jobs_cb[appid]
                 elif self.jobs_def_cb:
-                    logging.debug('calling application default finish callback with object %s', self.jobs_def_cb['f'])
+                    _logger.debug('calling application default finish callback with object %s', self.jobs_def_cb['f'])
                     try:
                         args = (*self.jobs_def_cb['args'], msg) if self.jobs_def_cb['args'] else (msg)
                         self.jobs_def_cb['f'](args)
                     except Exception as exc:
-                        logging.error('failed to call application default finish callback: %s', str(exc))
+                        _logger.error('failed to call application default finish callback: %s', str(exc))
                 else:
-                    logging.debug('NOT calling application finish callback')
+                    _logger.debug('NOT calling application finish callback')
             elif msg.get('status', None) == 'FINISHING':
                 await self.in_socket.send_json({'status': 'CONFIRMED'})
 
-                logging.debug('received notification with node agent finish: %s', str(msg))
+                _logger.debug('received notification with node agent finish: %s', str(msg))
 
                 if 'agent_id' in msg and msg['agent_id'] in self.nodes:
-                    logging.debug('removing node agent %s', msg['agent_id'])
+                    _logger.debug('removing node agent %s', msg['agent_id'])
                     del self.nodes[msg['agent_id']]
                 else:
-                    logging.error('node agent %s notifing FINISH not known', msg.get('agent_id', 'UNKNOWN'))
+                    _logger.error('node agent %s notifing FINISH not known', msg.get('agent_id', 'UNKNOWN'))
             else:
                 await self.in_socket.send_json({'status': 'ERROR'})
 
@@ -510,7 +513,7 @@ async def test():
         await run_job(launcher, 'n2', 'job2', ['/usr/bin/cat'], stdin='/etc/system-release', stdout='env2.out',
                       stderr='env2.err', env={'v1': 'V1_value', 'v2': ''})
     except Exception as exc:
-        logging.error(str(exc))
+        _logger.error(str(exc))
 
     await asyncio.sleep(5)
 

--- a/src/qcg/pilotjob/parseres.py
+++ b/src/qcg/pilotjob/parseres.py
@@ -5,6 +5,9 @@ from qcg.pilotjob.localres import parse_local_resources
 from qcg.pilotjob.slurmres import parse_slurm_resources, in_slurm_allocation
 
 
+_logger = logging.getLogger(__name__)
+
+
 def _detect_resources(config):
     """Return resource parse function according to actual environment.
 
@@ -19,17 +22,17 @@ def _detect_resources(config):
     Returns:
         function: function for parsing available resources
     """
-    logging.info('determining source of information about available resources ...')
+    _logger.info('determining source of information about available resources ...')
 
     if Config.EXECUTION_NODES.get(config):
-        logging.info('selected local resources information')
+        _logger.info('selected local resources information')
         return parse_local_resources(config)
 
     if in_slurm_allocation():
-        logging.info('selected SLURM resources information')
+        _logger.info('selected SLURM resources information')
         return parse_slurm_resources(config)
 
-    logging.info('selected local resources information')
+    _logger.info('selected local resources information')
     return parse_local_resources(config)
 
 
@@ -69,5 +72,5 @@ def get_resources(config):
     if res_source not in __RESOURCES_HANDLING__:
         raise ValueError('Invalid resources configuration setting: {}'.format(str(res_source)))
 
-    logging.info('source of information about available resources: %s', str(res_source))
+    _logger.info('source of information about available resources: %s', str(res_source))
     return __RESOURCES_HANDLING__[res_source](config)

--- a/src/qcg/pilotjob/partitions.py
+++ b/src/qcg/pilotjob/partitions.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 import zmq
 
+from qcg.pilotjob import logger as top_logger
 from qcg.pilotjob.config import Config
 from qcg.pilotjob.errors import InvalidRequest, JobAlreadyExist, InternalError
 from qcg.pilotjob.joblist import JobState
@@ -176,13 +177,13 @@ class PartitionManager:
                         '--slurm-limit-nodes-range-begin', str(self.start_node),
                         '--slurm-limit-nodes-range-end', str(self.end_node)]
 
-        if logging.root.level == logging.DEBUG:
+        if top_logger.level == logging.DEBUG:
             manager_args.extend(['--log', 'debug'])
 
         self.stdout_p = asyncio.subprocess.DEVNULL
         self.stderr_p = asyncio.subprocess.DEVNULL
 
-        if logging.root.level == logging.DEBUG:
+        if top_logger.level == logging.DEBUG:
             self.stdout_p = open(os.path.join(self.aux_dir, 'part-manager-{}-stdout.log'.format(self.mid)), 'w')
             self.stderr_p = open(os.path.join(self.aux_dir, 'part-manager-{}-stderr.log'.format(self.mid)), 'w')
 

--- a/src/qcg/pilotjob/reports.py
+++ b/src/qcg/pilotjob/reports.py
@@ -3,6 +3,9 @@ import logging
 import io
 
 
+_logger = logging.getLogger(__name__)
+
+
 class JobReport:
     """Base class for report generating classes.
 
@@ -72,7 +75,7 @@ class TextFileReport(JobReport):
             report_file (str): path to the report file
         """
         super(TextFileReport, self).__init__(report_file)
-        logging.info('initializing TEXT job report')
+        _logger.info('initializing TEXT job report')
 
     def report_job_entry(self, job, iteration, ostream):
         """Generate human readable entry for job's iteration.
@@ -106,7 +109,7 @@ class JsonFileReport(JobReport):
             report_file (str): path to the report file
         """
         super(JsonFileReport, self).__init__(report_file)
-        logging.info('initializing JSON job report')
+        _logger.info('initializing JSON job report')
 
     def report_job_entry(self, job, iteration, ostream):
         """Generate human readable entry for job's iteration.

--- a/src/qcg/pilotjob/request.py
+++ b/src/qcg/pilotjob/request.py
@@ -6,6 +6,9 @@ import uuid
 from qcg.pilotjob.errors import InvalidRequest
 
 
+_logger = logging.getLogger(__name__)
+
+
 class Request:
     """Base class for all requests.
 
@@ -176,7 +179,7 @@ class SubmitReq(Request):
 
         SubmitReq.REQ_CNT += 1
 
-        logging.debug('request data contains %s jobs', len(data['jobs']))
+        _logger.debug('request data contains %s jobs', len(data['jobs']))
         new_jobs = []
 
         for job_desc in data['jobs']:

--- a/src/qcg/pilotjob/resources.py
+++ b/src/qcg/pilotjob/resources.py
@@ -7,6 +7,9 @@ from qcg.pilotjob.allocation import CRAllocation, CRBindAllocation, NodeAllocati
 from qcg.pilotjob.errors import InternalError, NotSufficientResources
 
 
+_logger = logging.getLogger(__name__)
+
+
 class CRType(Enum):
     """Consumable resource type."""
 
@@ -623,7 +626,7 @@ class Resources:
 
             if min_nodes > self.total_nodes:
                 # not enough nodes
-                logging.info('Not enough nodes')
+                _logger.info('Not enough nodes')
                 return False
 
             if job_reqs.has_cores:
@@ -638,11 +641,11 @@ class Resources:
 
                 if found_nodes < min_nodes:
                     # not enough cores on nodes
-                    logging.info('Not enough suitable nodes')
+                    _logger.info('Not enough suitable nodes')
                     return False
 
         if job_reqs.get_min_num_cores() > self.total_cores:
-            logging.info('Not enough total cores')
+            _logger.info('Not enough total cores')
             return False
 
         return True

--- a/src/qcg/pilotjob/scheduleralgo.py
+++ b/src/qcg/pilotjob/scheduleralgo.py
@@ -5,6 +5,9 @@ from qcg.pilotjob.errors import InternalError, InvalidResourceSpec, NotSufficien
 from qcg.pilotjob.joblist import JobResources
 
 
+_logger = logging.getLogger(__name__)
+
+
 class SchedulerAlgorithm:
     """Scheduling algorithm.
 
@@ -127,13 +130,13 @@ class SchedulerAlgorithm:
         """
         allocation = Allocation()
 
-#        logging.info("allocating ({},{}) nodes with ({},{}) cores".format(min_nodes, max_nodes, min_cores, max_cores))
+#        _logger.info("allocating ({},{}) nodes with ({},{}) cores".format(min_nodes, max_nodes, min_cores, max_cores))
 
         for node in self.resources.nodes:
             if node.free >= min_cores:
                 node_alloc = node.allocate_max(max_cores, crs)
 
-#                logging.info("allocated {} cores on a single node".format(node_alloc.ncores if node_alloc else 0))
+#                _logger.info("allocated {} cores on a single node".format(node_alloc.ncores if node_alloc else 0))
 
                 if node_alloc:
                     if node_alloc.ncores >= min_cores:
@@ -145,11 +148,11 @@ class SchedulerAlgorithm:
                         node_alloc.release()
 
         if len(allocation.nodes) >= min_nodes:
-            logging.info("allocation contains %d nodes which meets requirements (%d min)", len(allocation.nodes),
+            _logger.info("allocation contains %d nodes which meets requirements (%d min)", len(allocation.nodes),
                          min_nodes)
             return allocation
 
-        logging.info("allocation contains %d nodes which doesn't meets requirements (%d min)", len(allocation.nodes),
+        _logger.info("allocation contains %d nodes which doesn't meets requirements (%d min)", len(allocation.nodes),
                      min_nodes)
         allocation.release()
         return None

--- a/src/qcg/pilotjob/service.py
+++ b/src/qcg/pilotjob/service.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from multiprocessing import Process
 from os.path import exists, join, isabs
 
+from qcg.pilotjob import logger as top_logger
 import qcg.pilotjob.profile
 from qcg.pilotjob.config import Config
 from qcg.pilotjob.errors import InvalidArgument
@@ -251,7 +252,7 @@ class QCGPMService:
             self._setup_address_file()
         except Exception:
             if self._log_handler:
-                logging.getLogger().removeHandler(self._log_handler)
+                logging.getLogger('qcg.pilotjob').removeHandler(self._log_handler)
                 self._log_handler = None
 
             raise
@@ -324,11 +325,10 @@ class QCGPMService:
         if exists(log_file):
             os.remove(log_file)
 
-        root_logger = logging.getLogger()
         self._log_handler = logging.FileHandler(filename=log_file, mode='a', delay=False)
         self._log_handler.setFormatter(logging.Formatter('%(asctime)-15s: %(message)s'))
-        root_logger.addHandler(self._log_handler)
-        root_logger.setLevel(logging._nameToLevel.get(Config.LOG_LEVEL.get(self._conf).upper()))
+        top_logger.addHandler(self._log_handler)
+        top_logger.setLevel(logging._nameToLevel.get(Config.LOG_LEVEL.get(self._conf).upper()))
 
         _logger.info('service %s version %s started %s @ %s (with tags %s)', Config.MANAGER_ID.get(self._conf),
                      qcg.pilotjob.__version__, str(datetime.now()), socket.gethostname(),
@@ -499,7 +499,7 @@ class QCGPMService:
 
 #           remove custom log handler
             if self._log_handler:
-                logging.getLogger().removeHandler(self._log_handler)
+                top_logger.removeHandler(self._log_handler)
 
     @staticmethod
     def get_rusage():

--- a/src/qcg/pilotjob/service.py
+++ b/src/qcg/pilotjob/service.py
@@ -538,18 +538,17 @@ class QCGPMServiceProcess(Process):
         this service is sent to calling thread.
         """
         try:
-            print('starting qcgpm service ...')
             self.service = QCGPMService(self.args)
 
             if self.queue:
-                print('communication queue defined ...')
+                _logger.info('communication queue defined ...')
                 zmq_ifaces = self.service.get_interfaces(ZMQInterface)
-                print('sending configuration through communication queue ...')
+                _logger.info('sending configuration through communication queue ...')
                 self.queue.put({'zmq_addresses': [str(iface.real_address) for iface in zmq_ifaces]})
             else:
-                print('communication queue not defined')
+                _logger.info('communication queue not defined')
 
-            print('starting qcgpm service inside process ....')
+            _logger.info('starting qcgpm service inside process ....')
             self.service.start()
         except Exception as exc:
             _logger.error('Error: %s', str(exc))

--- a/src/qcg/pilotjob/zmqinterface.py
+++ b/src/qcg/pilotjob/zmqinterface.py
@@ -8,6 +8,9 @@ from zmq.asyncio import Context
 from qcg.pilotjob.config import Config
 
 
+_logger = logging.getLogger(__name__)
+
+
 class ZMQInterface:
     """ZMQ interface for QCG-PilotJob.
 
@@ -67,14 +70,14 @@ class ZMQInterface:
             self.external_address = self.real_address.replace('//0.0.0.0:', '//{}:'.format(
                 socket.gethostbyname(socket.gethostname())))
 
-        logging.info('ZMQ interface configured (address %s) @ %s, external address @ %s', self.address,
+        _logger.info('ZMQ interface configured (address %s) @ %s, external address @ %s', self.address,
                      self.real_address, self.external_address)
 
     def close(self):
         """Close ZMQ socket."""
         if self.socket:
             try:
-                logging.info('closing ZMQ socket')
+                _logger.info('closing ZMQ socket')
                 self.socket.close()
             except Exception:
                 pass
@@ -85,11 +88,11 @@ class ZMQInterface:
         Returns:
             dict: incoming request
         """
-        logging.info("ZMQ interface listening for requests with pid %d...", os.getpid())
+        _logger.info("ZMQ interface listening for requests with pid %d...", os.getpid())
 
         req = await self.socket.recv()
 
-        logging.info("ZMQ interface received request ...")
+        _logger.info("ZMQ interface received request ...")
 
         return json.loads(bytes.decode(req))
 


### PR DESCRIPTION
This changes the log statements to use a module-local logger (named `qcg.pilotjob`) instead of the root logger, and everything that QCG-PJ does with the root logger is now done with the `qcg.pilotjob` logger so that it still works the same but does not disturb the rest of the program using it.

The PR also replaces with log statements (and in one case removes) any print statements run when QCG-PJ is used as a library.

Fixes #88, at least for me.