### PR TITLE
mp start method 

### DIFF
--- a/src/qcg/pilotjob/api/manager.py
+++ b/src/qcg/pilotjob/api/manager.py
@@ -674,12 +674,10 @@ class LocalManager(Manager):
               'log_file' - the location of the log file
               'log_level' - the log level ('DEBUG'); by default the log level is set to INFO
         """
-        if not mp.get_context():
-            _logger.debug('initializing MP start method with "fork"')
-            mp.set_start_method('fork')
-        else:
-            _logger.debug(f'MP start method already initialized with {mp.get_context().get_start_method()} method')
-
+        _logger.debug('initializing MP start method with "spawn"')
+        mp.set_start_method("spawn", force=True)
+        mp.freeze_support()
+                        
         try:
             from qcg.pilotjob.service import QCGPMServiceProcess
         except ImportError:


### PR DESCRIPTION
Changing multiprocessing start method in client API should solve problems with asyncio loop already started in jupyter notebooks.