### PR TITLE
Localmanager init timeout

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -19,75 +19,77 @@ The full list of currently supported options is presented below.
 .. code:: bash
 
    $ qcg-pm-service --help
-   usage: qcg-pm-service [-h] [--net] [--net-port NET_PORT]
-                         [--net-port-min NET_PORT_MIN]
-                         [--net-port-max NET_PORT_MAX] [--file]
-                         [--file-path FILE_PATH] [--wd WD]
-                         [--envschema ENVSCHEMA] [--resources RESOURCES]
-                         [--report-format REPORT_FORMAT]
-                         [--report-file REPORT_FILE] [--nodes NODES]
-                         [--log {critical,error,warning,info,debug,notset}]
-                         [--system-core] [--disable-nl] [--show-progress]
-                         [--governor] [--parent PARENT] [--id ID] [--tags TAGS]
-                         [--slurm-partition-nodes SLURM_PARTITION_NODES]
-                         [--slurm-limit-nodes-range-begin SLURM_LIMIT_NODES_RANGE_BEGIN]
-                         [--slurm-limit-nodes-range-end SLURM_LIMIT_NODES_RANGE_END]
-                         [--resume RESUME] [--openmpi-module OPENMPI_MODULE]
-                         [--enable-proc-stats]
+    usage: service.py [-h] [--net] [--net-port NET_PORT]
+                      [--net-port-min NET_PORT_MIN] [--net-port-max NET_PORT_MAX]
+                      [--file] [--file-path FILE_PATH] [--wd WD]
+                      [--envschema ENVSCHEMA] [--resources RESOURCES]
+                      [--report-format REPORT_FORMAT] [--report-file REPORT_FILE]
+                      [--nodes NODES]
+                      [--log {critical,error,warning,info,debug,notset}]
+                      [--system-core] [--disable-nl] [--show-progress]
+                      [--governor] [--parent PARENT] [--id ID] [--tags TAGS]
+                      [--slurm-partition-nodes SLURM_PARTITION_NODES]
+                      [--slurm-limit-nodes-range-begin SLURM_LIMIT_NODES_RANGE_BEGIN]
+                      [--slurm-limit-nodes-range-end SLURM_LIMIT_NODES_RANGE_END]
+                      [--resume RESUME] [--enable-proc-stats] [--enable-rt-stats]
+                      [--wrapper-rt-stats WRAPPER_RT_STATS]
+                      [--nl-init-timeout NL_INIT_TIMEOUT]
 
-   optional arguments:
-     -h, --help            show this help message and exit
-     --net                 enable network interface
-     --net-port NET_PORT   port to listen for network interface (implies --net)
-     --net-port-min NET_PORT_MIN
-                           minimum port range to listen for network interface if
-                           exact port number is not defined (implies --net)
-     --net-port-max NET_PORT_MAX
-                           maximum port range to listen for network interface if
-                           exact port number is not defined (implies --net)
-     --file                enable file interface
-     --file-path FILE_PATH
-                           path to the request file (implies --file)
-     --wd WD               working directory for the service
-     --envschema ENVSCHEMA
-                           job environment schema [auto|slurm]
-     --resources RESOURCES
-                           source of information about available resources
-                           [auto|slurm|local] as well as a method of job
-                           execution (through local processes or as a Slurm sub
-                           jobs)
-     --report-format REPORT_FORMAT
-                           format of job report file [text|json]
-     --report-file REPORT_FILE
-                           name of the job report file
-     --nodes NODES         configuration of available resources (implies
-                           --resources local)
-     --log {critical,error,warning,info,debug,notset}
-                           log level
-     --system-core         reserve one of the core for the QCG-PJM
-     --disable-nl          disable custom launching method
-     --show-progress       print information about executing tasks
-     --governor            run manager in the governor mode, where jobs will be
-                           scheduled to execute to the dependant managers
-     --parent PARENT       address of the parent manager, current instance will
-                           receive jobs from the parent manaqger
-     --id ID               optional manager instance identifier - will be
-                           generated automatically when not defined
-     --tags TAGS           optional manager instance tags separated by commas
-     --slurm-partition-nodes SLURM_PARTITION_NODES
-                           split Slurm allocation by given number of nodes, where
-                           each group will be controlled by separate manager
-                           (implies --governor)
-     --slurm-limit-nodes-range-begin SLURM_LIMIT_NODES_RANGE_BEGIN
-                           limit Slurm allocation to specified range of nodes
-                           (starting node)
-     --slurm-limit-nodes-range-end SLURM_LIMIT_NODES_RANGE_END
-                           limit Slurm allocation to specified range of nodes
-                           (ending node)
-     --resume RESUME       path to the QCG-PilotJob working directory to resume
-     --openmpi-module OPENMPI_MODULE
-                           name of the module to load before launching openmpi
-                           model job
-     --enable-proc-stats   gather information about launched processes from
-                           system
-
+    optional arguments:
+      -h, --help            show this help message and exit
+      --net                 enable network interface
+      --net-port NET_PORT   port to listen for network interface (implies --net)
+      --net-port-min NET_PORT_MIN
+                            minimum port range to listen for network interface if
+                            exact port number is not defined (implies --net)
+      --net-port-max NET_PORT_MAX
+                            maximum port range to listen for network interface if
+                            exact port number is not defined (implies --net)
+      --file                enable file interface
+      --file-path FILE_PATH
+                            path to the request file (implies --file)
+      --wd WD               working directory for the service
+      --envschema ENVSCHEMA
+                            job environment schema [auto|slurm]
+      --resources RESOURCES
+                            source of information about available resources
+                            [auto|slurm|local] as well as a method of job
+                            execution (through local processes or as a Slurm sub
+                            jobs)
+      --report-format REPORT_FORMAT
+                            format of job report file [text|json]
+      --report-file REPORT_FILE
+                            name of the job report file
+      --nodes NODES         configuration of available resources (implies
+                            --resources local)
+      --log {critical,error,warning,info,debug,notset}
+                            log level
+      --system-core         reserve one of the core for the QCG-PJM
+      --disable-nl          disable custom launching method
+      --show-progress       print information about executing tasks
+      --governor            run manager in the governor mode, where jobs will be
+                            scheduled to execute to the dependant managers
+      --parent PARENT       address of the parent manager, current instance will
+                            receive jobs from the parent manaqger
+      --id ID               optional manager instance identifier - will be
+                            generated automatically when not defined
+      --tags TAGS           optional manager instance tags separated by commas
+      --slurm-partition-nodes SLURM_PARTITION_NODES
+                            split Slurm allocation by given number of nodes, where
+                            each group will be controlled by separate manager
+                            (implies --governor)
+      --slurm-limit-nodes-range-begin SLURM_LIMIT_NODES_RANGE_BEGIN
+                            limit Slurm allocation to specified range of nodes
+                            (starting node)
+      --slurm-limit-nodes-range-end SLURM_LIMIT_NODES_RANGE_END
+                            limit Slurm allocation to specified range of nodes
+                            (ending node)
+      --resume RESUME       path to the QCG-PilotJob working directory to resume
+      --enable-proc-stats   gather information about launched processes from
+                            system
+      --enable-rt-stats     gather exact start & stop information of launched
+                            processes
+      --wrapper-rt-stats WRAPPER_RT_STATS
+                            exact start & stop information wrapper path
+      --nl-init-timeout NL_INIT_TIMEOUT
+                            node launcher init timeout (s)

--- a/src/qcg/pilotjob/api/job.py
+++ b/src/qcg/pilotjob/api/job.py
@@ -18,6 +18,7 @@ JOB_TOP_ATTRS = {
     "modules": {'req': False, 'types': [list, str]},
     "venv": {'req': False, 'types': [str]},
     "model": {'req': False, 'types': [str]},
+    "model_opts": {'req': False, 'types': [dict]},
     "numNodes": {'req': False, 'types': [int, dict]},
     "numCores": {'req': False, 'types': [int, dict]},
     "wt": {'req': False, 'types': [str]},
@@ -200,7 +201,7 @@ class Jobs:
         else:
             std_job.setdefault('execution', {})['script'] = smpl_job['script']
 
-        for key in ['args', 'stdin', 'stdout', 'stderr', 'wd', 'modules', 'venv', 'model']:
+        for key in ['args', 'stdin', 'stdout', 'stderr', 'wd', 'modules', 'venv', 'model', 'model_opts']:
             if key in smpl_job:
                 std_job['execution'][key] = smpl_job[key]
 
@@ -238,6 +239,7 @@ class Jobs:
         - ``modules`` (str or list(str), optional): list of modules that should be loaded before job start
         - ``venv`` (str, optional): path to the virtual environment that should be initialized before job start
         - ``model`` (str, optional): model of execution
+        - ``model_opts`` (dict, optional): model options
         - ``numCores`` (int or dict, optional): number of required cores specification
         - ``numNodes`` (int or dict, optional): number of required nodes specification
         - ``wt`` (str, optional): job's maximum wall time

--- a/src/qcg/pilotjob/config.py
+++ b/src/qcg/pilotjob/config.py
@@ -178,12 +178,6 @@ class Config(Enum):
         'default': None
     }
 
-    OPENMPI_MODEL_MODULE = {
-        'name': 'model.openmpi.module',
-        'cmd_opt': '--openmpi-module',
-        'default': 'openmpi'
-    }
-
     ENABLE_PROC_STATS = {
         'name': 'enable.proc.stats',
         'cmd_opt': '--enable-proc-stats',

--- a/src/qcg/pilotjob/config.py
+++ b/src/qcg/pilotjob/config.py
@@ -196,6 +196,12 @@ class Config(Enum):
         'default': 'qcg_pj_launch_wrapper'
     }
 
+    NL_INIT_TIMEOUT = {
+        'name': 'launcher.init.timeout',
+        'cmd_opt': '--nl-init-timeout',
+        'default': 600,
+    }
+
     def get(self, config):
         """Return configuration entry value from dictionary
 

--- a/src/qcg/pilotjob/joblist.py
+++ b/src/qcg/pilotjob/joblist.py
@@ -53,10 +53,11 @@ class JobExecution:
         venv (str, optional): path to the virtual environment to initialize before job start
         wd (str, optional): path to the job's working directory
         model (str, optional): model of execution
+        model_opts (str, optional): model options
     """
 
     def __init__(self, exec=None, args=None, env=None, script=None, stdin=None, stdout=None, stderr=None,
-                 modules=None, venv=None, wd=None, model=None):
+                 modules=None, venv=None, wd=None, model=None, model_opts=None):
         """Initialize execution element of job description.
 
         Args:
@@ -70,6 +71,7 @@ class JobExecution:
             venv (str, optional): path to the virtual environment to initialize before job start
             wd (str, optional): path to the job's working directory
             model (str, optional): model of execution
+            model_opts (dict(str, str), optional): model options
 
         Raises:
             IllegalJobDescription: when:
@@ -105,6 +107,13 @@ class JobExecution:
             self.model = model.lower()
         else:
             self.model = model
+
+        if model_opts is not None:
+            if not isinstance(model_opts, dict):
+                raise IllegalJobDescription("Execution model options must be an dictionary")
+            self.model_opts = model_opts
+        else:
+            self.model_opts = {}
 
         if args is not None:
             if not isinstance(args, list):
@@ -145,6 +154,9 @@ class JobExecution:
 
         if self.model is not None:
             result['model'] = self.model
+
+        if self.model_opts is not None:
+            result['model_opts'] = self.model_opts
 
         return result
 

--- a/src/qcg/pilotjob/launcher/launcher.py
+++ b/src/qcg/pilotjob/launcher/launcher.py
@@ -10,6 +10,8 @@ from datetime import datetime
 import zmq
 from zmq.asyncio import Context
 
+from qcg.pilotjob.config import Config
+
 from qcg.pilotjob import logger as top_logger
 
 
@@ -84,6 +86,10 @@ class Launcher:
         self.local_address = None
         self.local_export_address = None
         self.iface_task = None
+
+        self.agents_init_timeout = int(Config.NL_INIT_TIMEOUT.get(self.config))
+
+        _logger.info(f'timeout for node launcher agent start set to {self.agents_init_timeout} secs')
 
         self.connection_sem = asyncio.Semaphore(Launcher.MAXIMUM_CONCURRENT_CONNECTIONS)
 
@@ -373,7 +379,7 @@ class Launcher:
         start_t = datetime.now()
 
         while len(self.nodes) < len(self.agents):
-            if (datetime.now() - start_t).total_seconds() > Launcher.START_TIMEOUT_SECS:
+            if (datetime.now() - start_t).total_seconds() > self.agents_init_timeout:
                 _logger.error('timeout while waiting for agents - currenlty registered %s from launched %s',
                               len(self.nodes), len(self.agents))
                 _logger.error(f'not registered instances: ')

--- a/src/qcg/pilotjob/partitions.py
+++ b/src/qcg/pilotjob/partitions.py
@@ -181,7 +181,7 @@ class PartitionManager:
                             '--slurm-limit-nodes-range-end', str(self.end_node)]
 
             for arg in [Config.ZMQ_PORT_MIN_RANGE, Config.ZMQ_PORT_MAX_RANGE, Config.REPORT_FORMAT,
-                    Config.LOG_LEVEL, Config.OPENMPI_MODEL_MODULE, Config.WRAPPER_RT_STATS]:
+                    Config.LOG_LEVEL, Config.WRAPPER_RT_STATS]:
                 if self.config.get(arg, None) is not None:
                     manager_args.extend([arg.value['cmd_opt'], str(self.config.get(arg))])
 

--- a/src/qcg/pilotjob/service.py
+++ b/src/qcg/pilotjob/service.py
@@ -137,9 +137,6 @@ class QCGPMService:
         parser.add_argument(Config.RESUME.value['cmd_opt'],
                             help='path to the QCG-PilotJob working directory to resume',
                             default=None)
-        parser.add_argument(Config.OPENMPI_MODEL_MODULE.value['cmd_opt'],
-                            help='name of the module to load before launching openmpi model job',
-                            default=Config.OPENMPI_MODEL_MODULE.value['default'])
         parser.add_argument(Config.ENABLE_PROC_STATS.value['cmd_opt'],
                             help='gather information about launched processes from system',
                             default=Config.ENABLE_PROC_STATS.value['default'],
@@ -222,7 +219,6 @@ class QCGPMService:
             Config.SLURM_LIMIT_NODES_RANGE_BEGIN: self._args.slurm_limit_nodes_range_begin,
             Config.SLURM_LIMIT_NODES_RANGE_END: self._args.slurm_limit_nodes_range_end,
             Config.RESUME: self._args.resume,
-            Config.OPENMPI_MODEL_MODULE: self._args.openmpi_module,
             Config.ENABLE_PROC_STATS: self._args.enable_proc_stats,
             Config.ENABLE_RT_STATS: self._args.enable_rt_stats,
             Config.WRAPPER_RT_STATS: self._args.wrapper_rt_stats,

--- a/src/qcg/pilotjob/service.py
+++ b/src/qcg/pilotjob/service.py
@@ -148,6 +148,9 @@ class QCGPMService:
         parser.add_argument(Config.WRAPPER_RT_STATS.value['cmd_opt'],
                             help='exact start & stop information wrapper path',
                             default=Config.WRAPPER_RT_STATS.value['default'])
+        parser.add_argument(Config.NL_INIT_TIMEOUT.value['cmd_opt'],
+                            help='node launcher init timeout (s)',
+                            type=int, default=Config.NL_INIT_TIMEOUT.value['default'])
         self._args = parser.parse_args(args)
 
         if self._args.slurm_partition_nodes:
@@ -222,6 +225,7 @@ class QCGPMService:
             Config.ENABLE_PROC_STATS: self._args.enable_proc_stats,
             Config.ENABLE_RT_STATS: self._args.enable_rt_stats,
             Config.WRAPPER_RT_STATS: self._args.wrapper_rt_stats,
+            Config.NL_INIT_TIMEOUT: self._args.nl_init_timeout,
         }
 
     def __init__(self, args=None):

--- a/src/qcg/pilotjob/tests/test_governor.py
+++ b/src/qcg/pilotjob/tests/test_governor.py
@@ -620,7 +620,7 @@ def test_slurm_partition_resources():
             str(resources_reply)
 
         send_request_valid(governor_address, {'request': 'finish'})
-        governor_process.join(10)
+        governor_process.join(30)
         assert governor_process.exitcode == 0
     finally:
         if governor_process:


### PR DESCRIPTION
* a new client variable `init_timeout` used by LocalManager to set timeout for starting QCG-PilotJob manager service
* new job description field `model_opts` for passing parallel model options such as path to the mpirun command or mpirun additional arguments in openmpi model
* bugfix - kill QCG-PilotJob manager service started by LocalManager when not initialized properly in time
* bugfix - race condittion in iteration cancel
