### PR TITLE
Localmanager init timeout

### DIFF
--- a/src/qcg/pilotjob/launcher/rtstats.py
+++ b/src/qcg/pilotjob/launcher/rtstats.py
@@ -56,6 +56,7 @@ class RunTimeStats:
                             _logger.debug(f'child {pid} started: {started}, finished: {finished}')
                             self.rt_stats[pid] = {'s': started, 'f': finished}
         except Exception:
+            _logger.error(f'error to gather rt metrics')
             _logger.exception(f'error to gather rt metrics')
             raise
         finally:

--- a/src/qcg/pilotjob/utils/reportstats.py
+++ b/src/qcg/pilotjob/utils/reportstats.py
@@ -593,7 +593,7 @@ class JobsReportStats:
                 ))
         fig.write_image(output_file)
 
-    def resource_usage(self, details=False):
+    def resource_usage(self, from_first_job=False, details=False):
         resource_nodes = {}
         jobs = {}
         report = {}
@@ -607,7 +607,7 @@ class JobsReportStats:
 
         report['method'] = 'from_service_start'
 
-        if all((self.gstats.get('service_start'), self.gstats.get('service_finish'))):
+        if not from_first_job and all((self.gstats.get('service_start'), self.gstats.get('service_finish'))):
             min_start_moment = self.gstats.get('service_start')
             max_finish_moment = self.gstats.get('service_finish')
         else:
@@ -616,6 +616,8 @@ class JobsReportStats:
             report['method'] = 'from_first_job_start'
 
         total_time = (max_finish_moment - min_start_moment).total_seconds()
+        if self.verbose:
+            print(f'total time seconds: {total_time}')
 
         total_core_utilization = 0
         total_cores = 0 

--- a/utils/qcg_pj_launch_wrapper.c
+++ b/utils/qcg_pj_launch_wrapper.c
@@ -6,6 +6,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <string.h>
+#include <signal.h>
 
 
 #define DEBUG 0
@@ -51,6 +52,7 @@ int main(int argc, char **argv) {
         }
 
         child_exitcode = WEXITSTATUS(child_status);
+		signal(SIGPIPE, SIG_IGN);
 
 		if (debug_v) {
 			fprintf(stderr, "child job finished with %d exit code\n", child_exitcode);


### PR DESCRIPTION
* `--wo-init` option for rusage command to print resource usage without init & finish overheads
* ignore SIGPIPE in wrapper should prevent the `-13` task's exit code