### PR TITLE
bugfix: requirement package name

### DIFF
--- a/components/cmds/setup.py
+++ b/components/cmds/setup.py
@@ -27,7 +27,7 @@ setup(
         "qcg-pilotjob",
         "termcolor",
         "prompt_toolkit",
-        "plotly.express>=0.4.1",
+        "plotly_express>=0.4.1",
         "pandas",
         "kaleido"
     ],


### PR DESCRIPTION
* changed requirement package `plotly.express>=0.4.1` to `plotly_express>=0.4.1`