### PR TITLE
Issue 95: wait4all fixes

### DIFF
--- a/components/core/qcg/pilotjob/manager.py
+++ b/components/core/qcg/pilotjob/manager.py
@@ -649,6 +649,10 @@ class DirectManager:
                             _logger.warning("Job %s preserved in scheduling queue", sched_job.job.name)
                             DirectManager._append_to_schedule_queue(new_schedule_queue, sched_job)
 
+                none_running = self.queued_to_execute == 0 and self._executor.is_all_jobs_finished()
+                if none_running and len(self._schedule_queue) > 0 and len(new_schedule_queue) == 0:
+                    self._publish_no_jobs_event()
+
                 self._schedule_queue = new_schedule_queue
 
     def change_job_state(self, job, iteration, state, error_msg=None):


### PR DESCRIPTION
This fixes the two issues with `wait4all` mentioned in #95.

I have no experience with asyncio, so I may be wrong, but I think the potential case in where a job finishes just before the call to `self._publish_no_jobs_event` on line 654 of `manager.py` and sends a NO_JOBS event so that we get two stacked on top of each other cannot happen, because there is no `await` and so asyncio cannot context switch to handling the completion of the process in the `Executor`. But please check that that's the case.

For the new `wait4all` algorithm in `api/manager.py`, when the function is called there are three possible states the system can be in: 1) there's at least one job still running, 2) all jobs have finished and all notifications have been received, and 3) all jobs have finished but there are still pending notifications. On the client side, we can either have a status poller or not.

We first do a synchronous check to see if no jobs are running. If this returns `False`, then we must be in case 1), if it's `True` then we have case 2) or 3). If we don't have a poller, then we sleep-loop until the synchronous check returns `True`. If we do have a poller, then we check if there are pending events. At this point, we have the following possibilities:

A) `not all_finished and not events`: we're in case 1)
B) `not all_finished and events`: we're in case 1) and the last job just finished
C) `all_finished and not events`: we're in case 2)
D) `all_finished and events`: we're in case 3)

For A), we process the zero events we have, and start polling until we get events and find a NO_JOB, and return
For B), we process the events we have up to and including the NO_JOBS, and return
For C), we return immediately
For D), we process the events we have up to and including the NO_JOBS, and return

I replaced `not_finished` with `all_finished` because the double negation was giving me a headache :-).

I think this is correct, and I could reproduce the problem with the original code but not with this one.