### PR TITLE
Executor other args fix

### DIFF
--- a/components/executor_api/qcg/pilotjob/executor_api/qcgpj_executor.py
+++ b/components/executor_api/qcg/pilotjob/executor_api/qcgpj_executor.py
@@ -46,13 +46,13 @@ class QCGPJExecutor(Executor):
 
     """
     def __init__(self,
+                 *other_args,
                  wd=".",
                  resources=None,
                  reserve_core=False,
                  enable_rt_stats=False,
                  wrapper_rt_stats=None,
-                 log_level='info',
-                 *other_args
+                 log_level='info'
                  ):
 
         self.finished = False
@@ -82,7 +82,7 @@ class QCGPJExecutor(Executor):
             args.append(wrapper_rt_stats)
 
         if other_args:
-            args.append(other_args)
+            args.append(*other_args)
 
         client_conf = {'log_file': wd + '/api.log', 'log_level': client_log_level}
 

--- a/components/executor_api/qcg/pilotjob/executor_api/qcgpj_executor.py
+++ b/components/executor_api/qcg/pilotjob/executor_api/qcgpj_executor.py
@@ -82,7 +82,7 @@ class QCGPJExecutor(Executor):
             args.append(wrapper_rt_stats)
 
         if other_args:
-            args.append(*other_args)
+            args.extend(other_args)
 
         client_conf = {'log_file': wd + '/api.log', 'log_level': client_log_level}
 

--- a/components/executor_api/qcg/pilotjob/executor_api/qcgpj_executor.py
+++ b/components/executor_api/qcg/pilotjob/executor_api/qcgpj_executor.py
@@ -86,7 +86,8 @@ class QCGPJExecutor(Executor):
 
         client_conf = {'log_file': wd + '/api.log', 'log_level': client_log_level}
 
-        _logger.info(f'Starting QCG-PJ Manager with arguments: {args}')
+        with open("executor_api.log", "w") as f:
+            f.write(f'Starting QCG-PJ Manager with arguments: {args}')
 
         # create QCGPJ Manager (service part)
         self._qcgpjm = LocalManager(args, client_conf)

--- a/components/executor_api/qcg/pilotjob/executor_api/qcgpj_executor.py
+++ b/components/executor_api/qcg/pilotjob/executor_api/qcgpj_executor.py
@@ -86,7 +86,7 @@ class QCGPJExecutor(Executor):
 
         client_conf = {'log_file': wd + '/api.log', 'log_level': client_log_level}
 
-        with open("executor_api.log", "w") as f:
+        with open(wd + "/executor_api.log", "w") as f:
             f.write(f'Starting QCG-PJ Manager with arguments: {args}')
 
         # create QCGPJ Manager (service part)


### PR DESCRIPTION
QCGPJExecutor can now properly handle custom arguments for LocalManager