### PR TITLE
 removed slurmd_debug

### DIFF
--- a/components/core/qcg/pilotjob/launcher/launcher.py
+++ b/components/core/qcg/pilotjob/launcher/launcher.py
@@ -449,9 +449,6 @@ class Launcher:
                       f'{SlurmArg.CPU_BIND()}=none', '-vvv', '--mem-per-cpu=0', '--oversubscribe', '--overcommit',
                       '--overlap', '--nodes=1', '--ntasks=1', f'--cpus-per-task={node.total}', '-D', self.work_dir, '-u']
 
-        if top_logger.level == logging.DEBUG:
-            slurm_args.extend(['--slurmd-debug=verbose', '-vvvvv'])
-
         slurm_args.extend(slurm_data.get('args', []))
 
         stdout_p = asyncio.subprocess.DEVNULL


### PR DESCRIPTION
Using slurmd_debug requires special privileges and it seems to be available only for root and dedicated SlurmUser.